### PR TITLE
Use Carbon::createFromTimestamp for parsing timestamps

### DIFF
--- a/src/TargetsManager.php
+++ b/src/TargetsManager.php
@@ -67,6 +67,7 @@ class TargetsManager
         if ($this->isDateTarget($target, $index)) {
             if (filter_var($target, FILTER_VALIDATE_INT)) {
                 $target = (int)$target;
+                return Carbon::createFromTimestamp($target);
             }
             return Carbon::parse($target);
         }

--- a/src/TargetsManager.php
+++ b/src/TargetsManager.php
@@ -66,8 +66,7 @@ class TargetsManager
     {
         if ($this->isDateTarget($target, $index)) {
             if (filter_var($target, FILTER_VALIDATE_INT)) {
-                $target = (int)$target;
-                return Carbon::createFromTimestamp($target);
+                return Carbon::createFromTimestamp((int)$target);
             }
             return Carbon::parse($target);
         }


### PR DESCRIPTION
`Carbon::parse()` doesn't work with timestamps in some versions. I'm running `1.39.0` and it gives me an exception:

```
>>> Carbon::parse(1566247955);
Exception with message 'DateTime::__construct(): Failed to parse time string (1566247955) at position 7 (9): Unexpected character'
```

The solution is either to append a `@` to the timestamp `Carbon::parse('@' . 1566247955)` or use `Carbon::createFromTimestamp()`.

The recommendation from Carbon is the latter. See the comments here for more information:

https://github.com/briannesbitt/Carbon/issues/837#issuecomment-270327519