### PR TITLE
Support for base64 encoded cursor

### DIFF
--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -2,11 +2,13 @@
 
 namespace Amrnn\CursorPaginator;
 
+use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Amrnn\CursorPaginator\Exceptions\CursorPaginatorException;
+use Amrnn\CursorPaginator\Util\Base64Url;
 
-class Cursor implements Jsonable, Arrayable
+class Cursor implements JsonSerializable, Jsonable, Arrayable
 {
     public $direction;
     public $target;
@@ -29,6 +31,10 @@ class Cursor implements Jsonable, Arrayable
 
     public static function fromRequest($requestData)
     {
+        $cursorName = self::hashCursorName();
+        if(self::hashCursor() && isset($requestData[$cursorName])) {
+            $requestData = json_decode(Base64Url::decode($requestData[$cursorName]), true);
+        }
         foreach (array_keys(static::queryMappings()) as $direction) {
             if ($target = \Arr::get($requestData, $direction)) {
                 return new static($direction, $target);
@@ -90,7 +96,21 @@ class Cursor implements Jsonable, Arrayable
     public function urlParams()
     {
         if (!$this->isValid()) return null;
-        return [$this->direction => $this->target];
+        $params = [$this->direction => $this->target];
+        if(self::hashCursor()) {
+            $params = [ self::hashCursorName() => Base64Url::encode(json_encode($params))];
+        }
+        return $params;
+    }
+
+    protected static function hashCursor(): bool
+    {
+        return config('cursor_paginator.hash_cursor');
+    }
+
+    protected static function hashCursorName(): string
+    {
+        return config('cursor_paginator.hash_cursor_name', 'cursor');
     }
 
     public function isValid()
@@ -101,6 +121,9 @@ class Cursor implements Jsonable, Arrayable
     public function toArray()
     {
         if (!$this->isValid()) return null;
+        if(self::hashCursor()) {
+            return $this->urlParams();
+        }
         return [
             'direction' => $this->direction,
             'target' => $this->target
@@ -109,7 +132,16 @@ class Cursor implements Jsonable, Arrayable
 
     public function toJson($options = 0)
     {
-        return json_encode($this->toArray(), $options);
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    public function jsonSerialize()
+    {
+        if (!$this->isValid()) return null;
+        if(self::hashCursor()) {
+            return Base64Url::encode(json_encode([$this->direction => $this->target]));
+        }
+        return $this->toArray();
     }
 
     public function paginate($query, $perPage, $targetsManagerOptions = [])

--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -98,7 +98,7 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
         if (!$this->isValid()) return null;
         $params = [$this->direction => $this->target];
         if(self::encodeCursor()) {
-            $params = [ self::encodedCursorName() => Base64Url::encode(json_encode($params))];
+            $params = [ self::encodedCursorName() => Base64Url::encode(json_encode($params, JSON_NUMERIC_CHECK))];
         }
         return $params;
     }
@@ -139,7 +139,7 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
     {
         if (!$this->isValid()) return null;
         if(self::encodeCursor()) {
-            return Base64Url::encode(json_encode([$this->direction => $this->target]));
+            return Base64Url::encode(json_encode([$this->direction => $this->target],JSON_NUMERIC_CHECK));
         }
         return $this->toArray();
     }

--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -31,8 +31,8 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
 
     public static function fromRequest($requestData)
     {
-        $cursorName = self::hashCursorName();
-        if(self::hashCursor() && isset($requestData[$cursorName])) {
+        $cursorName = self::encodedCursorName();
+        if(self::encodeCursor() && isset($requestData[$cursorName])) {
             $requestData = json_decode(Base64Url::decode($requestData[$cursorName]), true);
         }
         foreach (array_keys(static::queryMappings()) as $direction) {
@@ -97,20 +97,20 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
     {
         if (!$this->isValid()) return null;
         $params = [$this->direction => $this->target];
-        if(self::hashCursor()) {
-            $params = [ self::hashCursorName() => Base64Url::encode(json_encode($params))];
+        if(self::encodeCursor()) {
+            $params = [ self::encodedCursorName() => Base64Url::encode(json_encode($params))];
         }
         return $params;
     }
 
-    protected static function hashCursor(): bool
+    protected static function encodeCursor(): bool
     {
-        return config('cursor_paginator.hash_cursor');
+        return config('cursor_paginator.encode_cursor');
     }
 
-    protected static function hashCursorName(): string
+    protected static function encodedCursorName(): string
     {
-        return config('cursor_paginator.hash_cursor_name', 'cursor');
+        return config('cursor_paginator.encoded_cursor_name', 'cursor');
     }
 
     public function isValid()
@@ -121,7 +121,7 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
     public function toArray()
     {
         if (!$this->isValid()) return null;
-        if(self::hashCursor()) {
+        if(self::encodeCursor()) {
             return $this->urlParams();
         }
         return [
@@ -138,7 +138,7 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
     public function jsonSerialize()
     {
         if (!$this->isValid()) return null;
-        if(self::hashCursor()) {
+        if(self::encodeCursor()) {
             return Base64Url::encode(json_encode([$this->direction => $this->target]));
         }
         return $this->toArray();

--- a/src/Util/Base64Url.php
+++ b/src/Util/Base64Url.php
@@ -4,7 +4,8 @@
 namespace Amrnn\CursorPaginator\Util;
 
 
-class Base64Url {
+class Base64Url
+{
     public static function encode(string $data): string
     {
         $encoded = base64_encode($data);

--- a/src/Util/Base64Url.php
+++ b/src/Util/Base64Url.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Amrnn\CursorPaginator\Util;
+
+
+class Base64Url {
+    public static function encode(string $data): string
+    {
+        $encoded = base64_encode($data);
+        $encoded = strtr($encoded, '+/', '-_');
+        return rtrim($encoded, '=');
+    }
+
+    public static function decode(string $data): string
+    {
+        $data = strtr($data, '-_', '+/');
+        return base64_decode($data);
+    }
+}

--- a/src/config/cursor_paginator.php
+++ b/src/config/cursor_paginator.php
@@ -23,7 +23,26 @@ return [
     /**
      * Default number of items per page.
      * 
-     * This can be overriden by passing a first argument to the `cursorPaginate()` method.
+     * This can be overridden by passing a first argument to the `cursorPaginate()` method.
      */
-    'per_page' => 10
+    'per_page' => 10,
+
+    /**
+     * Whether to hash url query.
+     *
+     * If set to true then your urls might look like:
+     * http://localhost:8000/cursor=eyJhZnRlciI6M30 instead of http://localhost:8000/after=3
+     */
+    'hash_cursor' => false,
+
+    /**
+     * Cursor url query name to use when `hash_cursor` set to is `true`.
+     *
+     * for example if you change:
+     * 'hash_cursor_name' => 'page-id'
+     *
+     * then your urls might look like:
+     * http://localhost:8000/page-id=eyJhZnRlciI6M30 instead of http://localhost:8000/cursor=eyJhZnRlciI6M30
+     */
+    'hash_cursor_name' => 'cursor',
 ];

--- a/src/config/cursor_paginator.php
+++ b/src/config/cursor_paginator.php
@@ -28,21 +28,21 @@ return [
     'per_page' => 10,
 
     /**
-     * Whether to hash url query.
+     * Whether to encode url query.
      *
      * If set to true then your urls might look like:
      * http://localhost:8000/cursor=eyJhZnRlciI6M30 instead of http://localhost:8000/after=3
      */
-    'hash_cursor' => false,
+    'encode_cursor' => false,
 
     /**
-     * Cursor url query name to use when `hash_cursor` set to is `true`.
+     * Cursor url query name to use when `encode_cursor` set to is `true`.
      *
      * for example if you change:
-     * 'hash_cursor_name' => 'page-id'
+     * 'encoded_cursor_name' => 'page-id'
      *
      * then your urls might look like:
      * http://localhost:8000/page-id=eyJhZnRlciI6M30 instead of http://localhost:8000/cursor=eyJhZnRlciI6M30
      */
-    'hash_cursor_name' => 'cursor',
+    'encoded_cursor_name' => 'cursor',
 ];

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -105,7 +105,7 @@ class MacroTest extends TestCase
             'before_i' => 'bi',
             'after' => 'a',
             'after_i' => 'ai'
-        ]]);
+        ], 'cursor_paginator.encode_cursor' => false]);
 
         $this->request(['b' => 5]);
         $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
@@ -117,6 +117,33 @@ class MacroTest extends TestCase
 
         $this->assertEquals(['direction' => 'ai', 'target' => 1], $paginatorData['first_page']->toArray());
         $this->assertEquals(['direction' => 'bi', 'target' => 10], $paginatorData['last_page']->toArray());
+    }
+
+
+    /** @test */
+    public function maps_encoded_cursor_from_config()
+    {
+        config(['cursor_paginator' => [
+            'encode_cursor' => true,
+            'encoded_cursor_name' => 'page-id',
+            'directions' => [
+                'before' => 'b',
+                'before_i' => 'bi',
+                'after' => 'a',
+                'after_i' => 'ai'
+            ]
+        ]]);
+
+        $this->request(['page-id' => 'eyJiIjo1fQ']);
+        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $this->assertEquals(['page-id' => 'eyJiIjo1fQ'], $paginatorData['current_page']->toArray());
+
+        $this->request(['page-id' => 'eyJhIjo1fQ']);
+        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $this->assertEquals(['page-id' => 'eyJhIjo1fQ'], $paginatorData['current_page']->toArray());
+
+        $this->assertEquals(['page-id' => 'eyJhaSI6MX0'], $paginatorData['first_page']->toArray());
+        $this->assertEquals(['page-id' => 'eyJiaSI6MTB9'], $paginatorData['last_page']->toArray());
     }
 
     /** @test */


### PR DESCRIPTION
Allow encoded cursor #4 by setting `'encode_cursor' => true` in config file.

Then we can use url query like 
`http://127.0.0.1:8000/api/posts?cursor=eyJhZnRlcl9pIjoiMjAxOS0xMC0yMiAwODowMDo1NSJ9`
which will provide following response:
```json
  {
       "data": [
            {
               ...
            }
        ],
        "per_page": 1,
        "total": 2,
        "next_item": {
           ...
        },
        "current_page": "eyJhZnRlcl9pIjoiMjAxOS0xMC0yMiAwODowMDo1NSJ9",
        "first_page": "eyJhZnRlcl9pIjoiMjAxOS0xMC0yMiAwODowMDo1NSJ9",
        "last_page": "eyJiZWZvcmVfaSI6IjIwMTktMTAtMjIgMDg6MDA6NTIifQ",
        "next_page": "eyJhZnRlciI6IjIwMTktMTAtMjIgMDg6MDA6NTUifQ",
        "previous_page": null,
        "first_page_url": "http://127.0.0.1:8000/api/posts?cursor=eyJhZnRlcl9pIjoiMjAxOS0xMC0yMiAwODowMDo1NSJ9",
        "last_page_url": "http://127.0.0.1:8000/api/posts?cursor=eyJiZWZvcmVfaSI6IjIwMTktMTAtMjIgMDg6MDA6NTIifQ",
        "next_page_url": "http://127.0.0.1:8000/api/posts?cursor=eyJhZnRlciI6IjIwMTktMTAtMjIgMDg6MDA6NTUifQ",
        "prev_page_url": null,
        "path": "http://127.0.0.1:8000/api/posts"
  }
```

We can change the url query parameter by setting `'encoded_cursor_name' => 'page-id'` which produces the url:
`http://127.0.0.1:8000/api/posts?page-id=eyJhZnRlcl9pIjoiMjAxOS0xMC0yMiAwODowMDo1NSJ9`
