### PR TITLE
feat: Added support for request arrays

### DIFF
--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -37,6 +37,12 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
         }
         foreach (array_keys(static::queryMappings()) as $direction) {
             if ($target = \Arr::get($requestData, $direction)) {
+                if (self::encodeCursor()) {
+                    $decodedTarget = json_decode(Base64Url::decode($target), true);
+                    if (is_array($decodedTarget) && $decodedTarget[$direction]) {
+                        return new static($direction, $decodedTarget[$direction]);
+                    }
+                }
                 return new static($direction, $target);
             }
         }

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -147,6 +147,32 @@ class MacroTest extends TestCase
     }
 
     /** @test */
+    public function maps_encoded_array_cursor_from_config()
+    {
+        config(['cursor_paginator' => [
+            'encode_cursor' => true,
+            'encoded_cursor_name' => 'page-id',
+            'directions' => [
+                'before' => 'page.b',
+                'before_i' => 'page.bi',
+                'after' => 'after.a',
+                'after_i' => 'after.ai'
+            ]
+        ]]);
+
+        $this->request(['page-id' => 'eyJhZnRlci5haSI6MX0']);
+        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $this->assertEquals(['page-id' => 'eyJhZnRlci5haSI6MX0'], $paginatorData['current_page']->toArray());
+
+        $this->request(['page-id' => 'eyJhZnRlci5haSI6MX0']);
+        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $this->assertEquals(['page-id' => 'eyJhZnRlci5haSI6MX0'], $paginatorData['current_page']->toArray());
+
+        $this->assertEquals(['page-id' => 'eyJhZnRlci5haSI6MX0'], $paginatorData['first_page']->toArray());
+        $this->assertEquals(['page-id' => 'eyJwYWdlLmJpIjoxMH0'], $paginatorData['last_page']->toArray());
+    }
+
+    /** @test */
     public function use_defaut_per_page_from_config()
     {
         $this->request(['before' => 5]);


### PR DESCRIPTION
Adding support for Requests that use params in array format.

```
GET /items?page[before]={cursor}
```