### PR TITLE
fix: use unionAll

### DIFF
--- a/src/Query/QueryMeta.php
+++ b/src/Query/QueryMeta.php
@@ -115,7 +115,7 @@ class QueryMeta
 
         $count = with(clone $query)->count();
         $firstLastQuery = $this->wrapQuery(
-            with(clone $query)->limit(1)->union(
+            with(clone $query)->limit(1)->unionAll(
                 with($this->reverseQueryOrders(clone $query))->limit(1)
             )
         );


### PR DESCRIPTION
Union does not work well with JSON columns:
````
could not identify an equality operator for type json
````

In this case we can also use `unionAll` because we don't need deduplication.