### PR TITLE
fix: use correct "as" parameter in fromSub

### DIFF
--- a/src/Query/QueryHelpers.php
+++ b/src/Query/QueryHelpers.php
@@ -111,7 +111,7 @@ trait QueryHelpers
             $this->removeOrders($inner);
         }
 
-        return $wrapper->fromSub($inner, null);
+        return $wrapper->fromSub($inner, 'wrap');
     }
 
     protected function ensureQueryIsOrdered($query)


### PR DESCRIPTION
Not sure how it worked before but passing `null` does not seem to work in my case (Laravel 8):
https://github.com/laravel/framework/blob/a4084639eea11ac2649325f4cd9a7c267d01a878/src/Illuminate/Database/Query/Builder.php#L280-L294