### PR TITLE
fix: use is_null

### DIFF
--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -115,7 +115,7 @@ class Cursor implements JsonSerializable, Jsonable, Arrayable
 
     public function isValid()
     {
-        return !(empty($this->direction) || empty($this->target));
+        return !(empty($this->direction) || is_null($this->target));
     }
 
     public function toArray()

--- a/src/Query/QueryMeta.php
+++ b/src/Query/QueryMeta.php
@@ -83,7 +83,7 @@ class QueryMeta
     {
         $itemsLastTarget = $this->targetsManager->targetFromItem($this->items->last());
 
-        if (!$itemsLastTarget) return null;
+        if (is_null($itemsLastTarget)) return null;
 
         return Cursor::after($itemsLastTarget);
     }


### PR DESCRIPTION
Sometimes the value can be empty (i.e. "0") and then these checks fail and it doesn't work correctly.