### PR TITLE
fix: use built-in where function

### DIFF
--- a/src/Query/PaginationStrategy/WhereApplier.php
+++ b/src/Query/PaginationStrategy/WhereApplier.php
@@ -26,7 +26,7 @@ class WhereApplier
             $comparator = $this->getComparatorForTarget($i);
 
             if ($i == 0) {
-                $this->query->whereRaw("`$column` $comparator ?", [$this->targets[$i]]);
+                $this->query->where($column, $comparator, $this->targets[$i]);
             } else {
                 $this->applyWhereForColumnsAfterFirst($i);
             }

--- a/src/Query/PaginationStrategy/WhereApplier.php
+++ b/src/Query/PaginationStrategy/WhereApplier.php
@@ -21,14 +21,22 @@ class WhereApplier
 
     public function applyWhere()
     {
-        for ($i = 0; $i < count($this->targets); $i++) {
+        $targets = $this->targets;
+        for ($i = 0; $i < count($targets); $i++) {
             $column = $this->getOrderColumn($this->query, $i);
             $comparator = $this->getComparatorForTarget($i);
 
             if ($i == 0) {
-                $this->query->where($column, $comparator, $this->targets[$i]);
+                $this->query->where($column, $comparator, $targets[$i]);
             } else {
-                $this->applyWhereForColumnsAfterFirst($i);
+                $this->query->where(function ($query) use ($i, $column, $comparator, $targets) {
+                    // Get previous column conditions
+                    for ($j = 0; $j < $i; $j++) {
+                        $query->where($this->getOrderColumn($this->query, $j), '=', $targets[$j]);
+                    }
+
+                    $query->where($column, $comparator, $targets[$i]);
+                }, null, null, 'and not');
             }
         }
         return $this->query;


### PR DESCRIPTION
Currently, I face a lot of issues (`operator does not exist`) because Postgres requires correct types (e.g. you cannot compare a string with a timestamp). Using this PR the conversions will be applied via Eloquent directly. In my opinion it also makes the where condition easier to read.