### PR TITLE
Renamed method cursorPaginate() to myCursorPaginate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ The package automatically registers itself, but if you need to you can add the s
 
 ## Usage
 
-This package provides a `cursorPaginate()` method that you can invoke on your Eloquent models or query builders:
+This package provides a `myCursorPaginate()` method that you can invoke on your Eloquent models or query builders:
 
 ```php
 Route::get('/posts', function() {
-    return Post::select('id')->orderBy('id', 'desc')->cursorPaginate(5);
+    return Post::select('id')->orderBy('id', 'desc')->myCursorPaginate(5);
 })
 ```
 
@@ -113,19 +113,19 @@ You can pass an optional first argument to `paginateCursor()` to specify the num
 
 ```php
 // will return 10 items per page
-Post::orderBy('id')->cursorPaginate(10);
+Post::orderBy('id')->myCursorPaginate(10);
 ```
 
 The package should automatically determine date casts by inspecting your model. However, if you're invoking the pagination on a plain query builder then you may need to pass a second argument which tells it about the date casts:
 
 ```php
 // no need to specify date casts here
-Post::orderBy('created_at')->cursorPaginate(10);
+Post::orderBy('created_at')->myCursorPaginate(10);
 
 // must tell a plain query builder about the dates
 DB::table('posts')
     ->orderBy('created_at')
-    ->cursorPaginate(10, ['dates' => ['created_at']]);
+    ->myCursorPaginate(10, ['dates' => ['created_at']]);
 ```
 
 ### Multiple Columns
@@ -133,9 +133,9 @@ DB::table('posts')
 You can order by multiple columns and pagination should work as expected:
 
 ```php
-Post::orderBy('created_at')->orderBy('id')->cursorPaginate();
+Post::orderBy('created_at')->orderBy('id')->myCursorPaginate();
 
-Post::orderBy('created_at', 'desc')->orderBy('id', 'desc'')->cursorPaginate();
+Post::orderBy('created_at', 'desc')->orderBy('id', 'desc'')->myCursorPaginate();
 ```
 
 > It's not recommended to mix directions (asc, desc) when ordering by multiple columns. Doing that would make using table indexes hard for your database.
@@ -145,17 +145,17 @@ Post::orderBy('created_at', 'desc')->orderBy('id', 'desc'')->cursorPaginate();
 All the columns that you're ordering by must also appear in your select statement, for example the following won't work:
 
 ```php
-Post::select('id')->orderBy('created_at')->cursorPaginate();
+Post::select('id')->orderBy('created_at')->myCursorPaginate();
 ```
 
 You have to do any of the following instead:
 
 ```php
-Post::select('id', 'created_at')->orderBy('created_at')->cursorPaginate();
+Post::select('id', 'created_at')->orderBy('created_at')->myCursorPaginate();
 
 // or
 
-Post::orderBy('created_at')->cursorPaginate()
+Post::orderBy('created_at')->myCursorPaginate()
 
 ```
 
@@ -204,7 +204,7 @@ return [
     /**
      * Default number of items per page.
      *
-     * This can be overridden by passing a first argument to the `cursorPaginate()` method.
+     * This can be overridden by passing a first argument to the `myCursorPaginate()` method.
      */
     'per_page' => 10,
 ];

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "amrnn/laravel-cursor-paginator",
+  "name": "lucianobosco/laravel-cursor-paginator",
   "description": "Cursor pagination for Laravel",
   "keywords": [
     "laravel",

--- a/src/PaginatorServiceProvider.php
+++ b/src/PaginatorServiceProvider.php
@@ -36,8 +36,8 @@ class PaginatorServiceProvider extends ServiceProvider
                 ->process($this);
         };
 
-        QueryBuilder::macro('cursorPaginate', $macro);
-        EloquentBuilder::macro('cursorPaginate', $macro);
+        QueryBuilder::macro('myCursorPaginate', $macro);
+        EloquentBuilder::macro('myCursorPaginate', $macro);
     }
 
 

--- a/src/config/cursor_paginator.php
+++ b/src/config/cursor_paginator.php
@@ -2,14 +2,14 @@
 
 return [
     /**
-     * 
+     *
      * Cursor direction names
-     * 
+     *
      * these appear in the url query string, change their mappings if you need to.
-     * for example if you change: 
-     * 
+     * for example if you change:
+     *
      * 'before' => 'b'
-     * 
+     *
      * then your urls might look like:
      * http://localhost:8000/b=10 instead of http://localhost:8000/before=10
      */
@@ -41,8 +41,8 @@ return [
 
     /**
      * Default number of items per page.
-     * 
-     * This can be overridden by passing a first argument to the `cursorPaginate()` method.
+     *
+     * This can be overridden by passing a first argument to the `myCursorPaginate()` method.
      */
     'per_page' => 10,
 ];

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -31,7 +31,7 @@ class MacroTest extends TestCase
     {
         $this->request(['before' => 1]);
 
-        $paginator = Reply::orderBy('id')->cursorPaginate();
+        $paginator = Reply::orderBy('id')->myCursorPaginate();
 
         $this->assertInstanceOf(CursorPaginator::class, $paginator);
     }
@@ -41,7 +41,7 @@ class MacroTest extends TestCase
     {
         $this->request(['before' => 5]);
 
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
 
         $this->assertEquals([2, 3, 4], collect($paginatorData['data'])->pluck('id')->all());
     }
@@ -50,7 +50,7 @@ class MacroTest extends TestCase
     public function paginator_returns_first_page_if_request_has_no_cursor()
     {
 
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
 
         $this->assertEquals([1, 2, 3], collect($paginatorData['data'])->pluck('id')->all());
         $this->assertEquals(new Cursor('after_i', 1), $paginatorData['current_page']);
@@ -66,7 +66,7 @@ class MacroTest extends TestCase
 
         $this->request(['before_i' => Carbon::create(2008)->timestamp]);
 
-        $paginatorData = Reply::orderBy('created_at')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('created_at')->myCursorPaginate(3)->toArray();
 
         $this->assertEquals(
             [2004, 2006, 2008],
@@ -85,7 +85,7 @@ class MacroTest extends TestCase
 
         $this->request(['before' => Carbon::create(2010)->timestamp]);
 
-        $paginatorData = DB::table('replies')->orderBy('created_at')->cursorPaginate(3, ['dates' => ['created_at']])->toArray();
+        $paginatorData = DB::table('replies')->orderBy('created_at')->myCursorPaginate(3, ['dates' => ['created_at']])->toArray();
 
         $this->assertEquals(
             [2006, 2008, 2009],
@@ -108,11 +108,11 @@ class MacroTest extends TestCase
         ], 'cursor_paginator.encode_cursor' => false]);
 
         $this->request(['b' => 5]);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
         $this->assertEquals(['direction' => 'b', 'target' => 5], $paginatorData['current_page']->toArray());
 
         $this->request(['a' => 5]);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
         $this->assertEquals(['direction' => 'a', 'target' => 5], $paginatorData['current_page']->toArray());
 
         $this->assertEquals(['direction' => 'ai', 'target' => 1], $paginatorData['first_page']->toArray());
@@ -135,11 +135,11 @@ class MacroTest extends TestCase
         ]]);
 
         $this->request(['page-id' => 'eyJiIjo1fQ']);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
         $this->assertEquals(['page-id' => 'eyJiIjo1fQ'], $paginatorData['current_page']->toArray());
 
         $this->request(['page-id' => 'eyJhIjo1fQ']);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
         $this->assertEquals(['page-id' => 'eyJhIjo1fQ'], $paginatorData['current_page']->toArray());
 
         $this->assertEquals(['page-id' => 'eyJhaSI6MX0'], $paginatorData['first_page']->toArray());
@@ -150,12 +150,12 @@ class MacroTest extends TestCase
     public function use_defaut_per_page_from_config()
     {
         $this->request(['before' => 5]);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate()->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate()->toArray();
         $this->assertEquals(10, $paginatorData['per_page']);
 
         config(['cursor_paginator.per_page' => 20]);
         $this->request(['before' => 5]);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate()->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate()->toArray();
         $this->assertEquals(20, $paginatorData['per_page']);
     }
 
@@ -163,7 +163,7 @@ class MacroTest extends TestCase
     public function allows_selecting_columns()
     {
         $this->request(['before' => 5]);
-        $paginatorData = Reply::select('id')->orderBy('id')->cursorPaginate()->toArray();
+        $paginatorData = Reply::select('id')->orderBy('id')->myCursorPaginate()->toArray();
 
         $this->assertEquals(['id' => 1], $paginatorData['data'][0]->toArray());
     }
@@ -172,7 +172,7 @@ class MacroTest extends TestCase
     public function paginator_result_contains_next_item()
     {
         $this->request(['after_i' => 1]);
-        $paginatorData = Reply::orderBy('id')->cursorPaginate(3)->toArray();
+        $paginatorData = Reply::orderBy('id')->myCursorPaginate(3)->toArray();
         $items = Reply::whereIn('id', [1, 2, 3])->get();
         $nextItem = Reply::find(4);
 


### PR DESCRIPTION
This change will rename `cursorPaginate()` method to `myCursorPaginate()` to avoid Laravel's native cursor paginate method call introduced in Laravel v 8.41.
